### PR TITLE
feat: add subcommand to restore local storage from on-chain data

### DIFF
--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -92,7 +92,7 @@ impl Args {
             Error::other(msg)
         })?;
 
-        let (deployer, deployer_key) = SecretKey::from_slice(&self.common.private_key.as_ref()[..])
+        let (deployer, deployer_key) = SecretKey::from_slice(&self.ckb.private_key.as_ref()[..])
             .map(|sk| {
                 let pk = sk.public_key(&SECP256K1);
                 let payload = CkbAddressPayload::from_pubkey(&pk);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -138,7 +138,7 @@ impl Args {
             tmp
         };
 
-        let (deployer, deployer_key) = SecretKey::from_slice(&self.common.private_key.as_ref()[..])
+        let (deployer, deployer_key) = SecretKey::from_slice(&self.ckb.private_key.as_ref()[..])
             .map(|sk| {
                 let pk = sk.public_key(&SECP256K1);
                 let payload = CkbAddressPayload::from_pubkey(&pk);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -182,7 +182,7 @@ impl Args {
             tmp
         };
 
-        let (deployer, deployer_key) = SecretKey::from_slice(&self.common.private_key.as_ref()[..])
+        let (deployer, deployer_key) = SecretKey::from_slice(&self.ckb.private_key.as_ref()[..])
             .map(|sk| {
                 let pk = sk.public_key(&SECP256K1);
                 let payload = CkbAddressPayload::from_pubkey(&pk);
@@ -354,7 +354,7 @@ impl Args {
             tmp
         };
 
-        let (deployer, deployer_key) = SecretKey::from_slice(&self.common.private_key.as_ref()[..])
+        let (deployer, deployer_key) = SecretKey::from_slice(&self.ckb.private_key.as_ref()[..])
             .map(|sk| {
                 let pk = sk.public_key(&SECP256K1);
                 let payload = CkbAddressPayload::from_pubkey(&pk);

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,0 +1,117 @@
+//! The `sync` sub-command.
+
+use std::path::PathBuf;
+
+use ckb_sdk::rpc::ResponseFormatGetter as _;
+use ckb_types::{
+    core::DepType,
+    packed::{CellDep, CellOutput, OutPoint},
+    prelude::*,
+};
+use clap::Parser;
+
+use crate::{
+    components::Storage,
+    prelude::*,
+    result::{Error, Result},
+    utilities::value_parsers,
+};
+
+#[derive(Parser)]
+pub struct Args {
+    #[clap(flatten)]
+    pub(crate) common: super::CommonArgs,
+
+    /// The directory, which stores all cached data.
+    #[arg(long)]
+    pub(crate) data_dir: PathBuf,
+
+    #[clap(flatten)]
+    pub(crate) ckb: super::CkbRoArgs,
+
+    #[clap(flatten)]
+    pub(crate) bitcoin: super::BitcoinArgs,
+
+    /// The out point of the Bitcoin SPV contract.
+    #[arg(long, value_parser = value_parsers::OutPointValueParser)]
+    pub(crate) spv_contract_out_point: OutPoint,
+
+    /// The out point of the lock contract.
+    ///
+    /// The lock contract has to satisfy that:
+    /// - If total capacity of cells which use this lock script were not
+    ///   decreased, any non-owner users can update them.
+    #[arg(long, value_parser = value_parsers::OutPointValueParser)]
+    pub(crate) lock_contract_out_point: OutPoint,
+
+    /// An out point of any cell in the target Bitcoin SPV instance.
+    #[arg(long, value_parser = value_parsers::OutPointValueParser)]
+    pub(crate) spv_cell_out_point: OutPoint,
+}
+
+impl Args {
+    pub fn execute(&self) -> Result<()> {
+        log::info!("Sync data to local storage base on on-chain Bitcoin SPV instance");
+
+        let ckb_cli = self.ckb.client();
+
+        let input_tx_hash = self.spv_cell_out_point.tx_hash();
+        let input_cell_index: u32 = self.spv_cell_out_point.index().unpack();
+        let input_cell_output: CellOutput = ckb_cli
+            .get_transaction(input_tx_hash.unpack())?
+            .ok_or_else(|| {
+                let msg = format!("CKB transaction {input_tx_hash:#x} is not existed");
+                Error::other(msg)
+            })?
+            .transaction
+            .ok_or_else(|| {
+                let msg = format!("remote server replied empty for transaction {input_tx_hash:#x}");
+                Error::other(msg)
+            })?
+            .get_value()?
+            .inner
+            .outputs
+            .get(input_cell_index as usize)
+            .ok_or_else(|| {
+                let msg = format!(
+                    "CKB transaction {input_tx_hash:#x} doesn't have \
+                    the {input_cell_index}-th output"
+                );
+                Error::other(msg)
+            })?
+            .to_owned()
+            .into();
+        let spv_type_script = input_cell_output.type_().to_opt().ok_or_else(|| {
+            let msg = format!(
+                "input cell (tx-hash: {input_tx_hash:#x}, index: {input_cell_index}) \
+                is not a SPV cell since no type script"
+            );
+            Error::other(msg)
+        })?;
+
+        let tip_spv_client_cell = ckb_cli.find_best_spv_client(spv_type_script.clone(), None)?;
+        let start_height = tip_spv_client_cell.client.headers_mmr_root.min_height;
+
+        let btc_cli = self.bitcoin.client();
+        let start_header = btc_cli.get_block_header_by_height(start_height)?;
+
+        let storage = Storage::new(&self.data_dir)?;
+        let _ = storage.initialize_with(start_height, start_header)?;
+
+        let spv_contract_cell_dep = CellDep::new_builder()
+            .out_point(self.spv_contract_out_point.clone())
+            .dep_type(DepType::Code.into())
+            .build();
+        let lock_contract_cell_dep = CellDep::new_builder()
+            .out_point(self.lock_contract_out_point.clone())
+            .dep_type(DepType::Code.into())
+            .build();
+        storage.save_cells_state(
+            spv_type_script,
+            spv_contract_cell_dep,
+            lock_contract_cell_dep,
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/components/ckb_client.rs
+++ b/src/components/ckb_client.rs
@@ -1,13 +1,111 @@
 //! Expand the functionality of the original CKB RPC client.
 
-use ckb_jsonrpc_types::TransactionView;
-use ckb_sdk::rpc::CkbRpcClient;
-use ckb_types::{packed, prelude::*, H256};
+use std::collections::HashMap;
 
-use crate::result::Result;
+use ckb_bitcoin_spv_verifier::types::{
+    core::{SpvClient, SpvInfo},
+    packed,
+    prelude::Unpack as VUnpack,
+};
+use ckb_jsonrpc_types::TransactionView;
+use ckb_sdk::{
+    rpc::{
+        ckb_indexer::{Order, SearchKey},
+        CkbRpcClient,
+    },
+    traits::{CellQueryOptions, LiveCell, PrimaryScriptType},
+};
+use ckb_types::{
+    packed::{Script, Transaction},
+    prelude::*,
+    H256,
+};
+
+use crate::result::{Error, Result};
+
+#[derive(Clone)]
+pub struct SpvInfoCell {
+    pub(crate) info: SpvInfo,
+    pub(crate) cell: LiveCell,
+    pub(crate) clients_count: u8,
+}
+
+#[derive(Clone)]
+pub struct SpvClientCell {
+    pub(crate) client: SpvClient,
+    pub(crate) cell: LiveCell,
+}
+
+pub struct SpvInstance {
+    pub(crate) info: SpvInfoCell,
+    pub(crate) clients: HashMap<u8, SpvClientCell>,
+}
+
+impl SpvInfoCell {
+    pub(crate) fn prev_tip_client_id(&self) -> u8 {
+        let current = self.info.tip_client_id;
+        if current == 0 {
+            self.clients_count - 1
+        } else {
+            current - 1
+        }
+    }
+
+    pub(crate) fn next_tip_client_id(&self) -> u8 {
+        let next = self.info.tip_client_id + 1;
+        if next < self.clients_count {
+            next
+        } else {
+            0
+        }
+    }
+}
 
 pub trait CkbRpcClientExtension {
     fn send_transaction_ext(&self, tx_json: TransactionView, dry_run: bool) -> Result<H256>;
+    fn find_raw_spv_cells(&self, spv_type_script: Script) -> Result<Vec<LiveCell>>;
+
+    fn find_spv_cells(&self, spv_type_script: Script) -> Result<SpvInstance> {
+        let cells = self.find_raw_spv_cells(spv_type_script)?;
+        parse_raw_spv_cells(cells)
+    }
+
+    fn find_best_spv_client(
+        &self,
+        spv_type_script: Script,
+        height_opt: Option<u32>,
+    ) -> Result<SpvClientCell> {
+        let SpvInstance { mut info, clients } = self.find_spv_cells(spv_type_script)?;
+        if let Some(height) = height_opt {
+            for _ in 0..clients.len() {
+                let cell = clients.get(&info.info.tip_client_id).ok_or_else(|| {
+                    let msg = format!(
+                        "the SPV client (id={}) is not found",
+                        info.info.tip_client_id
+                    );
+                    Error::other(msg)
+                })?;
+                if cell.client.headers_mmr_root.max_height <= height {
+                    return Ok(cell.to_owned());
+                }
+                info.info.tip_client_id = info.prev_tip_client_id();
+            }
+            let msg =
+                format!("all SPV clients have better heights than server has (height: {height})");
+            Err(Error::other(msg))
+        } else {
+            clients
+                .get(&info.info.tip_client_id)
+                .ok_or_else(|| {
+                    let msg = format!(
+                        "the SPV client (id={}) is not found",
+                        info.info.tip_client_id
+                    );
+                    Error::other(msg)
+                })
+                .cloned()
+        }
+    }
 }
 
 impl CkbRpcClientExtension for CkbRpcClient {
@@ -23,7 +121,7 @@ impl CkbRpcClientExtension for CkbRpcClient {
             }
         }
 
-        let tx: packed::Transaction = tx_json.inner.clone().into();
+        let tx: Transaction = tx_json.inner.clone().into();
         let tx_hash = tx.calc_tx_hash().unpack();
 
         if log::log_enabled!(log::Level::Debug) {
@@ -38,5 +136,75 @@ impl CkbRpcClientExtension for CkbRpcClient {
         }
 
         Ok(tx_hash)
+    }
+
+    fn find_raw_spv_cells(&self, spv_type_script: Script) -> Result<Vec<LiveCell>> {
+        let args_data = spv_type_script.args().raw_data();
+        let args = packed::SpvTypeArgsReader::from_slice(&args_data)
+            .map_err(|err| {
+                let msg = format!("the args of the SPV type script is invalid since {err}");
+                Error::other(msg)
+            })?
+            .unpack();
+
+        let query = CellQueryOptions::new(spv_type_script, PrimaryScriptType::Type);
+        let order = Order::Desc;
+        let search_key = SearchKey::from(query);
+
+        self.get_cells(search_key, order, u32::MAX.into(), None)
+            .map_err(Into::into)
+            .map(|res| res.objects)
+            .and_then(|cells| {
+                let actual = cells.len();
+                let expected = usize::from(args.clients_count) + 1;
+                if actual == expected {
+                    Ok(cells.into_iter().map(Into::into).collect())
+                } else {
+                    let msg = format!(
+                        "the count of SPV cells is incorrect, expect {expected} but got {actual}"
+                    );
+                    Err(Error::other(msg))
+                }
+            })
+    }
+}
+
+fn parse_raw_spv_cells(cells: Vec<LiveCell>) -> Result<SpvInstance> {
+    let mut spv_info_opt = None;
+    let mut spv_clients = HashMap::new();
+    let clients_count = (cells.len() - 1) as u8; // Checked when fetch SPV cells.
+    for cell in cells.into_iter() {
+        let data = &cell.output_data;
+        if let Ok(client) = packed::SpvClientReader::from_slice(data) {
+            let spv_cell = SpvClientCell {
+                client: client.unpack(),
+                cell,
+            };
+            spv_clients.insert(spv_cell.client.id, spv_cell);
+        } else if let Ok(info) = packed::SpvInfoReader::from_slice(data) {
+            if spv_info_opt.is_some() {
+                let msg = "the SPV info cell should be unique";
+                return Err(Error::other(msg));
+            }
+            let spv_cell = SpvInfoCell {
+                info: info.unpack(),
+                cell,
+                clients_count,
+            };
+            spv_info_opt = Some(spv_cell);
+        } else {
+            let msg = "the data of the SPV cell is unexpected";
+            return Err(Error::other(msg));
+        }
+    }
+    if let Some(spv_info) = spv_info_opt {
+        let instance = SpvInstance {
+            info: spv_info,
+            clients: spv_clients,
+        };
+        Ok(instance)
+    } else {
+        let msg = "the SPV info cell is missing";
+        Err(Error::other(msg))
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -9,6 +9,6 @@ mod spv_service;
 
 pub use api_service::ApiServiceConfig;
 pub use bitcoin_client::BitcoinClient;
-pub use ckb_client::CkbRpcClientExtension;
-pub use spv_service::{SpvClientCell, SpvOperation, SpvReorgInput, SpvService, SpvUpdateInput};
+pub use ckb_client::{CkbRpcClientExtension, SpvClientCell, SpvInfoCell, SpvInstance};
+pub use spv_service::{SpvOperation, SpvReorgInput, SpvService, SpvUpdateInput};
 pub use storage::{Error as StorageError, Storage};

--- a/src/components/spv_service.rs
+++ b/src/components/spv_service.rs
@@ -1,23 +1,14 @@
 //! Internal SPV service.
 
-use std::collections::HashMap;
-
 use ckb_bitcoin_spv_verifier::types::{
-    core::{Hash, SpvClient, SpvInfo},
-    packed,
+    core::Hash,
     prelude::{Pack as VPack, Unpack as VUnpack},
 };
-use ckb_sdk::{
-    rpc::{
-        ckb_indexer::{Order, SearchKey},
-        CkbRpcClient,
-    },
-    traits::{CellQueryOptions, LiveCell, PrimaryScriptType},
-};
+use ckb_sdk::rpc::CkbRpcClient;
 use ckb_types::prelude::*;
 
 use crate::{
-    components::{BitcoinClient, Storage},
+    components::{BitcoinClient, SpvClientCell, SpvInfoCell, SpvInstance, Storage},
     prelude::*,
     result::{Error, Result},
 };
@@ -27,24 +18,6 @@ pub struct SpvService {
     pub(crate) ckb_cli: CkbRpcClient,
     pub(crate) btc_cli: BitcoinClient,
     pub(crate) storage: Storage,
-}
-
-#[derive(Clone)]
-pub struct SpvInfoCell {
-    pub(crate) info: SpvInfo,
-    pub(crate) cell: LiveCell,
-    pub(crate) clients_count: u8,
-}
-
-#[derive(Clone)]
-pub struct SpvClientCell {
-    pub(crate) client: SpvClient,
-    pub(crate) cell: LiveCell,
-}
-
-pub struct SpvInstance {
-    pub(crate) info: SpvInfoCell,
-    pub(crate) clients: HashMap<u8, SpvClientCell>,
 }
 
 pub struct SpvUpdateInput {
@@ -64,48 +37,16 @@ pub enum SpvOperation {
     Reorg(SpvReorgInput),
 }
 
-impl SpvInfoCell {
-    pub(crate) fn prev_tip_client_id(&self) -> u8 {
-        let current = self.info.tip_client_id;
-        if current == 0 {
-            self.clients_count - 1
-        } else {
-            current - 1
-        }
-    }
-
-    pub(crate) fn next_tip_client_id(&self) -> u8 {
-        let next = self.info.tip_client_id + 1;
-        if next < self.clients_count {
-            next
-        } else {
-            0
-        }
-    }
-}
-
 impl SpvService {
     pub(crate) fn find_best_spv_client(&self, height: u32) -> Result<SpvClientCell> {
-        let SpvInstance { mut info, clients } = self.find_spv_cells()?;
-        for _ in 0..clients.len() {
-            let cell = clients.get(&info.info.tip_client_id).ok_or_else(|| {
-                let msg = format!(
-                    "the SPV client (id={}) is not found",
-                    info.info.tip_client_id
-                );
-                Error::other(msg)
-            })?;
-            if cell.client.headers_mmr_root.max_height <= height {
-                return Ok(cell.to_owned());
-            }
-            info.info.tip_client_id = info.prev_tip_client_id();
-        }
-        let msg = format!("all SPV clients have better heights than server has (height: {height})");
-        Err(Error::other(msg))
+        let spv_type_script = self.storage.spv_contract_type_script()?;
+        self.ckb_cli
+            .find_best_spv_client(spv_type_script, Some(height))
     }
 
     pub(crate) fn select_operation(&self) -> Result<SpvOperation> {
-        let ins = self.find_spv_cells()?;
+        let spv_type_script = self.storage.spv_contract_type_script()?;
+        let ins = self.ckb_cli.find_spv_cells(spv_type_script)?;
         let spv_client_curr = ins
             .clients
             .get(&ins.info.info.tip_client_id)
@@ -190,43 +131,6 @@ impl SpvService {
         Err(Error::other(msg))
     }
 
-    pub(crate) fn find_spv_cells(&self) -> Result<SpvInstance> {
-        let cells = self.find_raw_spv_cells()?;
-        parse_raw_spv_cells(cells)
-    }
-
-    pub(crate) fn find_raw_spv_cells(&self) -> Result<Vec<LiveCell>> {
-        let spv_type_script = self.storage.spv_contract_type_script()?;
-        let args_data = spv_type_script.args().raw_data();
-        let args = packed::SpvTypeArgsReader::from_slice(&args_data)
-            .map_err(|err| {
-                let msg = format!("the args of the SPV type script is invalid since {err}");
-                Error::other(msg)
-            })?
-            .unpack();
-
-        let query = CellQueryOptions::new(spv_type_script, PrimaryScriptType::Type);
-        let order = Order::Desc;
-        let search_key = SearchKey::from(query);
-
-        self.ckb_cli
-            .get_cells(search_key, order, u32::MAX.into(), None)
-            .map_err(Into::into)
-            .map(|res| res.objects)
-            .and_then(|cells| {
-                let actual = cells.len();
-                let expected = usize::from(args.clients_count) + 1;
-                if actual == expected {
-                    Ok(cells.into_iter().map(Into::into).collect())
-                } else {
-                    let msg = format!(
-                        "the count of SPV cells is incorrect, expect {expected} but got {actual}"
-                    );
-                    Err(Error::other(msg))
-                }
-            })
-    }
-
     pub(crate) fn sync_storage(&self) -> Result<bool> {
         let spv = &self;
         let (stg_tip_height, stg_tip_header) = spv.storage.tip_state()?;
@@ -299,45 +203,5 @@ impl SpvService {
         let _ = spv.storage.append_headers(headers)?;
 
         Ok(true)
-    }
-}
-
-fn parse_raw_spv_cells(cells: Vec<LiveCell>) -> Result<SpvInstance> {
-    let mut spv_info_opt = None;
-    let mut spv_clients = HashMap::new();
-    let clients_count = (cells.len() - 1) as u8; // Checked when fetch SPV cells.
-    for cell in cells.into_iter() {
-        let data = &cell.output_data;
-        if let Ok(client) = packed::SpvClientReader::from_slice(data) {
-            let spv_cell = SpvClientCell {
-                client: client.unpack(),
-                cell,
-            };
-            spv_clients.insert(spv_cell.client.id, spv_cell);
-        } else if let Ok(info) = packed::SpvInfoReader::from_slice(data) {
-            if spv_info_opt.is_some() {
-                let msg = "the SPV info cell should be unique";
-                return Err(Error::other(msg));
-            }
-            let spv_cell = SpvInfoCell {
-                info: info.unpack(),
-                cell,
-                clients_count,
-            };
-            spv_info_opt = Some(spv_cell);
-        } else {
-            let msg = "the data of the SPV cell is unexpected";
-            return Err(Error::other(msg));
-        }
-    }
-    if let Some(spv_info) = spv_info_opt {
-        let instance = SpvInstance {
-            info: spv_info,
-            clients: spv_clients,
-        };
-        Ok(instance)
-    } else {
-        let msg = "the SPV info cell is missing";
-        Err(Error::other(msg))
     }
 }


### PR DESCRIPTION
### Steps

- Alice `init` a Bitcoin SPV instance on her PC.
- Alice `serve` a service on her machine.
- Bob finds a transaction from A's Bitcoin SPV instance.
- Bob `sync` data to his laptop.
- Bob can `serve` a service on his laptop for the same Bitcoin SPV instance, too.