### PR TITLE
ci: remove non-existent tests in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CARGO := @cargo
 
-NEXTEST_RUN_ARGS := --no-fail-fast --success-output immediate --failure-output final
+NEXTEST_RUN_ARGS := --no-fail-fast --success-output never --failure-output final
 
 #
 # Check
@@ -16,7 +16,7 @@ clippy:
 	${CARGO} clippy --workspace --tests -- --deny warnings
 
 test:
-	${CARGO} nextest run ${NEXTEST_RUN_ARGS} --workspace types::extension::packed::test_service
+	${CARGO} nextest run ${NEXTEST_RUN_ARGS} --workspace
 
 #
 # Build


### PR DESCRIPTION
### Description

<details><summary>No such tests.</summary><br/>

To be honest, this project has no unit tests.
Such a service requires integration tests rather than unit tests, and write integration tests in Rust is a terrible nightmare.
The correctness is depended on works of our test team.

</details>

When I copied a `Makefile` as the template from another project (`ckb-bitcoin-spv`), I forgot to remove the temporary code which is used for debugging.