### PR TITLE
refactor: don't allow `limit = 0`

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,6 +1,9 @@
 //! The `serve` sub-command.
 
-use std::{cmp::Ordering, collections::HashMap, net::SocketAddr, path::PathBuf, thread, time};
+use std::{
+    cmp::Ordering, collections::HashMap, net::SocketAddr, num::NonZeroU32, path::PathBuf, thread,
+    time,
+};
 
 use ckb_bitcoin_spv_verifier::types::{core::SpvClient, packed, prelude::Pack as VPack};
 use ckb_jsonrpc_types::{Status, TransactionView};
@@ -64,9 +67,8 @@ pub struct Args {
 
     /// Don't update all headers in one CKB transaction,
     /// to avoid size limit or cycles limit.
-    /// `0` means no limit.
     #[arg(long, default_value = "10")]
-    pub(crate) spv_headers_update_limit: u32,
+    pub(crate) spv_headers_update_limit: NonZeroU32,
 
     /// The batch size that how many Bitcoin headers will be downloaded at once.
     #[arg(long, default_value = "30")]
@@ -158,8 +160,8 @@ impl Args {
 
                     let spv_tip_height = input.curr.client.headers_mmr_root.max_height;
 
-                    let (spv_client, spv_update) =
-                        storage.generate_spv_client_and_spv_update(spv_tip_height, 0)?;
+                    let (spv_client, spv_update) = storage
+                        .generate_spv_client_and_spv_update(spv_tip_height, NonZeroU32::MAX)?;
 
                     let tx_hash =
                         self.reorg_spv_cells(&spv_service, input, spv_client, spv_update)?;

--- a/src/components/storage/prelude.rs
+++ b/src/components/storage/prelude.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use bitcoin::constants::DIFFCHANGE_INTERVAL;
 use ckb_bitcoin_spv_verifier::{
     types::{
@@ -158,11 +160,11 @@ pub(crate) trait BitcoinSpvStorage: InternalBitcoinSpvStorage {
     fn generate_spv_client_and_spv_update(
         &self,
         prev_height: u32,
-        limit: u32,
+        limit: NonZeroU32,
     ) -> Result<(SpvClient, packed::SpvUpdate)> {
         let mut tip_height = self.get_tip_bitcoin_height()?;
-        if limit > 0 && tip_height > prev_height.saturating_add(limit) {
-            tip_height = prev_height.saturating_add(limit);
+        if tip_height > prev_height.saturating_add(limit.into()) {
+            tip_height = prev_height.saturating_add(limit.into());
         }
         log::trace!("new tip height will be {tip_height}, prev {prev_height}, limit {limit}",);
         let tip_header = self.get_bitcoin_header(tip_height)?;


### PR DESCRIPTION
### Description

> Personally, I feel `0 means no limit` is a bit special. Without special treatment, it should mean forbidden.
> 
> Another way to change（for reference only）
> 
> ```rust
> storage.generate_spv_client_and_spv_update(spv_tip_height, None)? ;
> ```
> 
> ```rust
>   if let Some(limit) = limit {
>       tip_height = std::cmp::min(tip_height, prev_height.saturating_add(limit));
>   }
> ```

_Originally posted by @EthanYuan in https://github.com/ckb-cell/ckb-bitcoin-spv-service/pull/14#discussion_r1548875442_
            