### PR TITLE
fix: failed to reorg when only one stale block

### DIFF
--- a/src/components/spv_service.rs
+++ b/src/components/spv_service.rs
@@ -113,12 +113,20 @@ impl SpvService {
             let packed_spv_header_root = spv_header_root.pack();
 
             if packed_stg_header_root.as_slice() == packed_spv_header_root.as_slice() {
-                let input = SpvReorgInput {
-                    info,
-                    curr: cell.clone(),
-                    stale,
-                };
-                return Ok(input);
+                if stale.len() > 1 {
+                    let input = SpvReorgInput {
+                        info,
+                        curr: cell.clone(),
+                        stale,
+                    };
+                    return Ok(input);
+                } else {
+                    log::warn!(
+                        "[TODO::KnownIssue] this is a dirty patch to fix an issue in the contract: \
+                        update and reorg only 1 block are indistinguishable, \
+                        let's just reorg 1 more client"
+                    );
+                }
             }
 
             log::trace!("[onchain] header#{spv_height}; mmr-root {spv_header_root}");


### PR DESCRIPTION
### Description

This is a contract issue:

- When update Bitcoin SPV instance:

  ```yaml
  Cell Deps:
  - Type Lock
  - SPV Client (id=k)
  - ... ...
  Inputs:
  - SPV Info (tip_client_id=k)
  - SPV Client (id=k+1)
  - ... ...
  Outputs:
  - SPV Info (tip_client_id=k+1)
  - SPV Client (id=k+1)
  - ... ...
  Witnesses:
  - SPV Update
  - ... ...
  ```

- When reorg Bitcoin SPV instance when only 1 stale block:

  ```yaml
  Cell Deps:
  - Type Lock
  - SPV Client (id=k)
  - ... ...
  Inputs:
  - SPV Info (tip_client_id=k+1)
  - SPV Client (id=k+1)
  - ... ...
  Outputs:
  - SPV Info (tip_client_id=k+1)
  - SPV Client (id=k+1)
  - ... ...
  Witnesses:
  - SPV Update
  - ... ...
  ```

**They have exactly the same structure, but different `tip-client-id` in the SPV info cell.**

So, the contract couldn't distinguish the operation for them.

### Solution (Urgent, maybe Temporary)

Reorg two Bitcoin SPV clients when they are only 1 stale block.

PROS:
- Quick to apply the patch, don't have to re-deploy the contract.

CONS:
- Larger transaction, causes a bit more fee.

### My Own Opionion

I think it may be a good final solution.

Since update and reorg-1 are so similar, and reorg are small probability events, adding a tag to all operations is not a good deal.