### PR TITLE
feat: try increasing file descriptor soft limit for service at start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "clap-verbosity-flag",
  "env_logger",
  "faster-hex 0.9.0",
+ "fdlimit",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
@@ -1141,6 +1142,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fdlimit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
+dependencies = [
+ "libc",
+ "thiserror",
+]
 
 [[package]]
 name = "fixed-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ zeroize = { version = "1.7", features = ["derive"] }
 url = "2.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+fdlimit = "0.3"
 
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking"] }
 jsonrpc-core         = "18.0"

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     prelude::*,
     result::{Error, Result},
+    utilities::try_raise_fd_limit,
 };
 
 #[derive(Parser)]
@@ -82,6 +83,8 @@ pub struct Args {
 impl Args {
     pub fn execute(&self) -> Result<()> {
         log::info!("Starting the Bitcoin SPV service");
+
+        try_raise_fd_limit();
 
         let storage = Storage::new(&self.data_dir)?;
         if !storage.is_initialized()? {

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -8,6 +8,7 @@ use crate::{
     components::{ApiServiceConfig, SpvService, Storage},
     prelude::*,
     result::{Error, Result},
+    utilities::try_raise_fd_limit,
 };
 
 #[derive(Parser)]
@@ -44,6 +45,8 @@ pub struct Args {
 impl Args {
     pub fn execute(&self) -> Result<()> {
         log::info!("Starting the Bitcoin SPV service (readonly)");
+
+        try_raise_fd_limit();
 
         let storage = Storage::new(&self.data_dir)?;
         if !storage.is_initialized()? {

--- a/src/components/api_service/mod.rs
+++ b/src/components/api_service/mod.rs
@@ -128,7 +128,6 @@ impl SpvRpc for SpvRpcImpl {
         })?;
         log::trace!(">>> tip height in local storage is {stg_tip_height}");
 
-        // TODO Define server errors with enum.
         if stg_tip_height < target_height {
             let desc = format!(
                 "target transaction is in header#{target_height}, \

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,8 +1,10 @@
 //! Utilities.
 
 mod key;
+mod platform;
 mod type_id;
 pub(crate) mod value_parsers;
 
 pub(crate) use key::Key256Bits;
+pub(crate) use platform::try_raise_fd_limit;
 pub(crate) use type_id::calculate_type_id;

--- a/src/utilities/platform.rs
+++ b/src/utilities/platform.rs
@@ -1,0 +1,17 @@
+//! Enhance the platform environment for continuously running services.
+
+use fdlimit::{raise_fd_limit, Outcome};
+
+pub fn try_raise_fd_limit() {
+    match raise_fd_limit() {
+        Ok(Outcome::LimitRaised { from, to }) => {
+            log::info!("raise file descriptor resource limit from {from} to {to}");
+        }
+        Ok(Outcome::Unsupported) => {
+            log::warn!("raising limit is not supported on this platform");
+        }
+        Err(err) => {
+            log::error!("failed to raise file descriptor resource limit, since {err}");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Resolve #23.

### How to test?

First, set the soft limit and hard limit with different values:

```shell
ulimit -Sn 1024
sudo ulimit -Hn 65536
```

then run `ckb-bitcoin-spv-service serve -v ...`, the log outputs will contain the following message:

```
[2024-04-10THH:MM:SSZ INFO  ckb_bitcoin_spv_service::utilities::platform] raise file descriptor resource limit from 1024 to 65536
```