### PR TITLE
chore: update a terrible function naming

### DIFF
--- a/src/components/api_service/mod.rs
+++ b/src/components/api_service/mod.rs
@@ -268,7 +268,7 @@ impl SpvRpc for SpvRpcImpl {
         };
 
         let spv_client_cell = spv_instance
-            .find_best_spv_client_include_height(stg_tip_height)
+            .find_best_spv_client_not_greater_than_height(stg_tip_height)
             .map_err(|err| {
                 let message = format!(
                     "failed to get SPV cell base on height {stg_tip_height} from fetched data"

--- a/src/components/ckb_client.rs
+++ b/src/components/ckb_client.rs
@@ -79,7 +79,7 @@ pub trait CkbRpcClientExtension {
     ) -> Result<SpvClientCell> {
         let instance = self.find_spv_cells(spv_type_script)?;
         if let Some(height) = height_opt {
-            instance.find_best_spv_client_include_height(height)
+            instance.find_best_spv_client_not_greater_than_height(height)
         } else {
             instance.find_tip_spv_client()
         }
@@ -174,7 +174,10 @@ impl SpvInstance {
             .cloned()
     }
 
-    pub(crate) fn find_best_spv_client_include_height(&self, height: u32) -> Result<SpvClientCell> {
+    pub(crate) fn find_best_spv_client_not_greater_than_height(
+        &self,
+        height: u32,
+    ) -> Result<SpvClientCell> {
         let SpvInstance { ref info, clients } = self;
         let mut info = info.to_owned();
         for _ in 0..clients.len() {


### PR DESCRIPTION
### Description

> Yep!
> 
> If expect storage to generate a headers proof for on-chain headers, then storage has to contain more headers than on-chain.
> 
> ---
> 
> It's a terrible function name. That's why you were confused.
> 
> I guess when I wrote this function, I think about the best SPV client should be included in storage, so I just wrote such a terrible name.
> 
> A best name should be `find_best_spv_client_under_height`.



_Original post by [comment in PR-25](https://github.com/ckb-cell/ckb-bitcoin-spv-service/pull/25/files#r1571003941)_